### PR TITLE
Add rudimentary HTTP support

### DIFF
--- a/mc.bat
+++ b/mc.bat
@@ -1,4 +1,5 @@
 @echo off
 setlocal
-    set MPM_ROOT=.\.mpm\ && kotlinc -script mc.kts %*
+    set MPM_ROOT=.\.mpm\
+    kotlinc -script mc.kts %*
 endlocal

--- a/std/http.m
+++ b/std/http.m
@@ -1,0 +1,22 @@
+;;; http.m
+;;;
+;;; An HTTP client for M (temporary)
+
+;; Send a request synchronously, returning a process
+(extern http/send)
+
+;; Supported HTTP methods
+(def http/GET   (symbol GET))
+(def http/HEAD  (symbol HEAD))
+(def http/POST  (symbol POST))
+(def http/PUT   (symbol PUT))
+(def http/PATCH (symbol PATCH))
+(def http/DELETE (symbol DELETE))
+
+;; Convenience methods for each HTTP method
+(defn http/get url headers body    (http/send http/GET url headers body))
+(defn http/head url headers body   (http/send http/HEAD url headers body))
+(defn http/post url headers body   (http/send http/POST url headers body))
+(defn http/put url headers body    (http/send http/PUT url headers body))
+(defn http/patch url headers body  (http/send http/PATCH url headers body))
+(defn http/delete url headers body  (http/send http/DELETE url headers body))


### PR DESCRIPTION
Changes proposed in this pull request:
- HTTP support in the standard library

The HTTP support will be temporary, to aide in getting m-pods set up until we can separate http into it's own library