### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/m.m linguist-generated


### PR DESCRIPTION
This pull request will stop github from automatically expanding the diff on the m.m file generated when bootstrapping the compiler.